### PR TITLE
Allow an account to be exclusively multisigned (RIPD-182):

### DIFF
--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -187,8 +187,18 @@ SetAccount::doApply ()
             return tecNEED_MASTER_KEY;
         }
 
-        if (!sle->isFieldPresent (sfRegularKey))
+        if ((!sle->isFieldPresent (sfRegularKey)) &&
+            (!view().peek (keylet::signers (getSignerListIndex (account_)))))
+        {
+            // Account has no regular key or multi-signer signer list.
+
+            // Prevent transaction changes until we're ready.
+            if ((RIPPLE_ENABLE_MULTI_SIGN) ||
+                (view().flags() & tapENABLE_TESTING))
+                    return tecNO_ALTERNATIVE_KEY;
+
             return tecNO_REGULAR_KEY;
+        }
 
         j_.trace << "Set lsfDisableMaster.";
         uFlagsOut |= lsfDisableMaster;

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -73,8 +73,18 @@ SetRegularKey::doApply ()
     }
     else
     {
-        if (sle->isFlag (lsfDisableMaster))
+        if ((sle->isFlag (lsfDisableMaster)) &&
+            (!view().peek (keylet::signers (getSignerListIndex (account_)))))
+        {
+            // Account has disabled master key and no multi-signer signer list.
+
+            // Prevent transaction changes until we're ready.
+            if ((RIPPLE_ENABLE_MULTI_SIGN) ||
+                (view().flags() & tapENABLE_TESTING))
+                    return tecNO_ALTERNATIVE_KEY;
+
             return tecMASTER_DISABLED;
+        }
         sle->makeFieldAbsent (sfRegularKey);
     }
 

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -79,7 +79,8 @@ private:
     TER replaceSignerList (uint256 const& index);
     TER destroySignerList (uint256 const& index);
 
-    void writeSignersToLedger (SLE::pointer ledgerEntry);
+    TER removeSignersFromLedger (uint256 const& index);
+    void writeSignersToSLE (SLE::pointer ledgerEntry);
 
     static std::size_t ownerCountDelta (std::size_t entryCount);
 };

--- a/src/ripple/app/tx/tests/MultiSign.test.cpp
+++ b/src/ripple/app/tx/tests/MultiSign.test.cpp
@@ -436,6 +436,78 @@ public:
         env.require (owners (alice, 0));
     }
 
+    // We want to always leave an account signable.  Make sure the that we
+    // disallow removing the last way a transaction may be signed.
+    void test_keyDisable()
+    {
+        using namespace jtx;
+        Env env(*this);
+        Account const alice {"alice", KeyType::ed25519};
+        env.fund(XRP(1000), alice);
+
+        // There are three negative tests we need to make:
+        //  M0. A lone master key cannot be disabled.
+        //  R0. A lone regular key cannot be removed.
+        //  L0. A lone signer list cannot be removed.
+        //
+        // Additionally, there are 6 positive tests we need to make:
+        //  M1. The master key can be disabled if there's a regular key.
+        //  M2. The master key can be disabled if there's a signer list.
+        //
+        //  R1. The regular key can be removed if there's a signer list.
+        //  R2. The regular key can be removed if the master key is enabled.
+        //
+        //  L1. The signer list can be removed if the master key is enabled.
+        //  L2. The signer list can be removed if there's a regular key.
+
+        // Master key tests.
+        // M0: A lone master key cannot be disabled.
+        env(fset (alice, asfDisableMaster),
+            sig(alice), ter(tecNO_ALTERNATIVE_KEY));
+
+        // Add a regular key.
+        Account const alie {"alie", KeyType::ed25519};
+        env(regkey (alice, alie));
+
+        // M1: The master key can be disabled if there's a regular key.
+        env(fset (alice, asfDisableMaster), sig(alice));
+
+        // R0: A lone regular key cannot be removed.
+        env(regkey (alice, disabled), sig(alie), ter(tecNO_ALTERNATIVE_KEY));
+
+        // Add a signer list.
+        env(signers(alice, 1, {{bogie, 1}}), sig (alie));
+
+        // R1: The regular key can be removed if there's a signer list.
+        env(regkey (alice, disabled), sig(alie));
+
+        // L0; A lone signer list cannot be removed.
+        env(signers(alice, jtx::none), msig(bogie), ter(tecNO_ALTERNATIVE_KEY));
+
+        // Enable the master key.
+        env(fclear (alice, asfDisableMaster), msig(bogie));
+
+        // L1: The signer list can be removed if the master key is enabled.
+        env(signers(alice, jtx::none), msig(bogie));
+
+        // Add a signer list.
+        env(signers(alice, 1, {{bogie, 1}}), sig (alice));
+        // M2: The master key can be disabled if there's a signer list.
+        env(fset (alice, asfDisableMaster), sig(alice));
+
+        // Add a regular key.
+        env(regkey (alice, alie), msig(bogie));
+
+        // L2: The signer list can be removed if there's a regular key.
+        env(signers(alice, jtx::none), sig(alie));
+
+        // Enable the master key.
+        env(fclear (alice, asfDisableMaster), sig(alie));
+
+        // R2: The regular key can be removed if the master key is enabled.
+        env(regkey (alice, disabled), sig(alie));
+    }
+
     // See if every kind of transaction can be successfully multi-signed.
     void test_txTypes()
     {
@@ -524,6 +596,7 @@ public:
         test_masterSigners();
         test_regularSigners();
         test_heterogeneousSigners();
+        test_keyDisable();
         test_txTypes();
     }
 };

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -200,6 +200,7 @@ enum TER
     tecNEED_MASTER_KEY          = 142,
     tecDST_TAG_NEEDED           = 143,
     tecINTERNAL                 = 144,
+    tecNO_ALTERNATIVE_KEY       = 145,
 };
 
 inline bool isTelLocal(TER x)

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -68,6 +68,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tecNEED_MASTER_KEY,       "tecNEED_MASTER_KEY",       "The operation requires the use of the Master Key."             },
         { tecDST_TAG_NEEDED,        "tecDST_TAG_NEEDED",        "A destination tag is required."                                },
         { tecINTERNAL,              "tecINTERNAL",              "An internal error has occurred during processing."             },
+        { tecNO_ALTERNATIVE_KEY,    "tecNO_ALTERNATIVE_KEY",    "The operation would remove the last way to sign a transaction."},
 
         { tefALREADY,               "tefALREADY",               "The exact transaction was already in this ledger."             },
         { tefBAD_ADD_AUTH,          "tefBAD_ADD_AUTH",          "Not authorized to add account."                                },

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -332,7 +332,7 @@ public:
         env.require(nflags("alice", asfDisableMaster));
         env(fset("alice", asfDisableMaster), sig("alice"));
         env.require(flags("alice", asfDisableMaster));
-        env(regkey("alice", disabled),                          ter(tecMASTER_DISABLED));
+        env(regkey("alice", disabled),                          ter(tecNO_ALTERNATIVE_KEY));
         env(noop("alice"));
         env(noop("alice"), sig("alice"),                        ter(tefMASTER_DISABLED));
         env(noop("alice"), sig("eric"));


### PR DESCRIPTION
The capabilities of multisigning are intended to be roughly
comparable to those of a regular key.  It is currently possible
to make an account that can only be signed using its regular key.
This is done by disabling the master key.  Since that's true, it
seems like it should be possible to do the same if an account is
multisignable (because it has a SignerList).

However, rippled goes to some effort to try and make sure an
account is always signable through some means.  So, for example,
rippled prevents a user from disabling their master key unless they
have a regular key in place.  Similarly, if an account's master key
is disabled rippled will not allow the user to remove their regular
key.  They can change the regular key, but they may not remove it.

To account for multisigning, and still provide comparable safety,
here are the rules this pull request employs:

 o An account can always add or replace a regular key or a
   SignerList as long as the fee and reserve can be met by the
   account.

 o The master key on an account can be disabled if either a
   regular key or a SignerList (or both) is present on the account.
   Either the regular key or the SignerList can be used to
   re-enable the master key later if that is desired.

 o The regular key on an account may only be removed if either the
   master key is enabled or the account has a SignerList (or both).

 o The SignerList on an account may only be removed if either the
   master key is enabled or a regular key is present (or both).
