### PR TITLE
Add SignerList support to account_objects (RIPD-1061)

### DIFF
--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -335,6 +335,7 @@ JSS ( server_state );               // out: NetworkOPs
 JSS ( server_status );              // out: NetworkOPs
 JSS ( severity );                   // in: LogLevel
 JSS ( signature );                  // out: NetworkOPs
+JSS ( signer_list_count );          // out: account_info
 JSS ( snapshot );                   // in: Subscribe
 JSS ( source_account );             // in: PathRequest, RipplePathFind
 JSS ( source_amount );              // in: PathRequest, RipplePathFind

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -72,6 +72,11 @@ Json::Value doAccountInfo (RPC::Context& context)
     {
         RPC::injectSLE(jvAccepted, *sleAccepted);
         result[jss::account_data] = jvAccepted;
+
+        // Flag whether account is multisigning.
+        auto const sleSignerList = ledger->read (keylet::signers (accountID));
+        int const listCount = sleSignerList ? 1 : 0;
+        result[jss::account_data][jss::signer_list_count] = listCount;
     }
     else
     {

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -89,6 +89,7 @@ Json::Value doAccountObjects (RPC::Context& context)
             { "fee", ltFEE_SETTINGS },
             { "hashes", ltLEDGER_HASHES },
             { "offer", ltOFFER },
+            { "signerlist", ltSIGNER_LIST, },
             { "state", ltRIPPLE_STATE },
             { "ticket", ltTICKET }
         };


### PR DESCRIPTION
Apparently recovering the SignerList from an account will be a common problem for API users.  This change is intended to help in two ways:
1. An account_info response now contains a field that indicates how many SignerLists are attached to the account.  For a non-multisigning account that count will be zero.
2. The account_objects command now accepts a "signerlist" type, so only the SignerLists on an account will be returned.

The request in the JIRA item (https://ripplelabs.atlassian.net/browse/RIPD-1061) is to actually include the SignerList in the account_info response.  I'm not following that path because a year or so ago I was including the SignerList in the account_info and was told to remove it in favor or using account_objects to return the SignerList.  

The account_info returns a count in anticipation of a future that might support multiple signer lists.  The response looks like this:

```
{
   "result" : {
      "account_data" : {
         "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
         ...
         "Sequence" : 2,
         "index" : "3E85929FA644A46D1A96D685D00B5A4BDEB90FD1D7D7FCD1C556DDC79CDF8101",
         "signer_list_count" : 0
      },
      "ledger_current_index" : 5,
      "status" : "success",
      "validated" : false
   }
}
```

Another approach would be to return `"multi signing": <true | false>` if we don't care to tip our hand about the potential for multiple signer lists.
