### PR TITLE
Flow offer cross

### DIFF
--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -63,6 +63,7 @@ flow (
     bool defaultPaths,
     bool partialPayment,
     bool ownerPaysTransferFee,
+    bool offerCrossing,
     boost::optional<Quality> const& limitQuality,
     boost::optional<STAmount> const& sendMax,
     beast::Journal j)
@@ -84,7 +85,7 @@ flow (
     // convert the paths to a collection of strands. Each strand is the collection
     // of account->account steps and book steps that may be used in this payment.
     auto sr = toStrands (sb, src, dst, dstIssue, sendMaxIssue, paths,
-        defaultPaths, ownerPaysTransferFee, j);
+        defaultPaths, ownerPaysTransferFee, offerCrossing, j);
 
     if (sr.first != tesSUCCESS)
     {

--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -84,8 +84,8 @@ flow (
 
     // convert the paths to a collection of strands. Each strand is the collection
     // of account->account steps and book steps that may be used in this payment.
-    auto sr = toStrands (sb, src, dst, dstIssue, sendMaxIssue, paths,
-        defaultPaths, ownerPaysTransferFee, offerCrossing, j);
+    auto sr = toStrands (sb, src, dst, dstIssue, limitQuality, sendMaxIssue,
+        paths, defaultPaths, ownerPaysTransferFee, offerCrossing, j);
 
     if (sr.first != tesSUCCESS)
     {

--- a/src/ripple/app/paths/Flow.h
+++ b/src/ripple/app/paths/Flow.h
@@ -38,9 +38,11 @@ namespace ripple
   @param defaultPaths Include defaultPaths in the path set
   @param partialPayment If the payment cannot deliver the entire
            requested amount, deliver as much as possible, given the constraints
+  @param ownerPaysTransferFee If true then owner, not receiver, pays fee
+  @param offerCrossing We are offer crossing, so use special rules
   @param limitQuality Do not use liquidity below this quality threshold
   @param sendMax Do not spend more than this amount
-  @param logs Logs to write journal messages to
+  @param j Journal to write journal messages to
   @return Actual amount in and out, and the result code
 */
 path::RippleCalc::Output
@@ -52,6 +54,7 @@ flow (PaymentSandbox& view,
     bool defaultPaths,
     bool partialPayment,
     bool ownerPaysTransferFee,
+    bool offerCrossing,
     boost::optional<Quality> const& limitQuality,
     boost::optional<STAmount> const& sendMax,
     beast::Journal j);

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -137,7 +137,7 @@ RippleCalc::Output RippleCalc::rippleCalculate (
                     view.rules ().enabled (featureOwnerPaysFee, config.features);
             flowV2Out = flow (flowV2SB, saDstAmountReq, uSrcAccountID,
                 uDstAccountID, spsPaths, defaultPaths, partialPayment,
-                ownerPaysTransferFee, limitQuality, sendMax, j);
+                ownerPaysTransferFee, /* offerCrossing */ false, limitQuality, sendMax, j);
         }
         catch (std::exception& e)
         {

--- a/src/ripple/app/paths/impl/AmountSpec.h
+++ b/src/ripple/app/paths/impl/AmountSpec.h
@@ -103,6 +103,18 @@ struct EitherAmount
         else
             iou = a.iou;
     }
+
+    explicit
+    EitherAmount (STAmount const& a)
+    {
+#ifndef NDEBUG
+        native = a.native();
+#endif
+        if (a.native())
+            xrp = a.xrp();
+        else
+            iou = a.iou();
+    }
 };
 
 template <class T>

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -239,6 +239,7 @@ toStrand (
     boost::optional<Issue> const& sendMaxIssue,
     STPath const& path,
     bool ownerPaysTransferFee,
+    bool offerCrossing,
     beast::Journal j);
 
 /**
@@ -267,6 +268,7 @@ toStrands (ReadView const& sb,
     STPathSet const& paths,
     bool addDefaultPath,
     bool ownerPaysTransferFee,
+    bool offerCrossing,
     beast::Journal j);
 
 template <class TIn, class TOut, class TDerived>
@@ -350,9 +352,11 @@ struct StrandContext
     ReadView const& view;
     AccountID const strandSrc;
     AccountID const strandDst;
+    Issue const strandDeliver;
     bool const isFirst;
     bool const isLast = false;
     bool ownerPaysTransferFee;
+    bool const offerCrossing;
     size_t const strandSize;
     // The previous step in the strand. Needed to check the no ripple constraint
     Step const* const prevStep = nullptr;
@@ -369,10 +373,12 @@ struct StrandContext
         std::vector<std::unique_ptr<Step>> const& strand_,
         // A strand may not include an inner node that
         // replicates the source or destination.
-        AccountID strandSrc_,
-        AccountID strandDst_,
+        AccountID const& strandSrc_,
+        AccountID const& strandDst_,
+        Issue const& strandDeliver_,
         bool isLast_,
         bool ownerPaysTransferFee_,
+        bool offerCrossing_,
         std::array<boost::container::flat_set<Issue>, 2>& seenDirectIssues_,
         boost::container::flat_set<Issue>& seenBookOuts_,
         beast::Journal j);

--- a/src/ripple/app/tests/Flow_test.cpp
+++ b/src/ripple/app/tests/Flow_test.cpp
@@ -181,8 +181,8 @@ struct Flow_test : public beast::unit_test::suite
             boost::optional<Issue> const& sendMaxIssue, STPath const& path,
             TER expTer, auto&&... expSteps)
         {
-            auto r = toStrand (*env.current (), alice, bob,
-                deliver, sendMaxIssue, path, true, env.app ().logs ().journal ("Flow"));
+            auto r = toStrand (*env.current (), alice, bob, deliver,
+                sendMaxIssue, path, true, false, env.app ().logs ().journal ("Flow"));
             expect (r.first == expTer);
             if (sizeof...(expSteps))
                 expect (equal (
@@ -235,21 +235,21 @@ struct Flow_test : public beast::unit_test::suite
                 auto flowJournal = env.app ().logs ().journal ("Flow");
                 {
                     // The root account can't be the dst
-                    auto r = toStrand (*env.current (), alice,
-                        xrpAccount (), XRP, USD.issue (), STPath (), true, flowJournal);
+                    auto r = toStrand (*env.current (), alice, xrpAccount (),
+                        XRP, USD.issue (), STPath (), true, false, flowJournal);
                     expect (r.first == temBAD_PATH);
                 }
                 {
                     // The root account can't be the src
                     auto r =
-                        toStrand (*env.current (), xrpAccount (),
-                            alice, XRP, boost::none, STPath (), true, flowJournal);
+                        toStrand (*env.current (), xrpAccount (), alice,
+                            XRP, boost::none, STPath (), true, false, flowJournal);
                     expect (r.first == temBAD_PATH);
                 }
                 {
                     // The root account can't be the src
-                    auto r = toStrand (*env.current (),
-                        noAccount (), bob, USD, boost::none, STPath (), true, flowJournal);
+                    auto r = toStrand (*env.current (), noAccount (),
+                        bob, USD, boost::none, STPath (), true, false, flowJournal);
                     expect (r.first == terNO_ACCOUNT);
                 }
             }
@@ -358,8 +358,8 @@ struct Flow_test : public beast::unit_test::suite
             test (env, USD, boost::none, STPath (), terNO_AUTH);
 
             // Check pure issue redeem still works
-            auto r = toStrand (*env.current (), alice, gw, USD,
-                boost::none, STPath (), true, env.app ().logs ().journal ("Flow"));
+            auto r = toStrand (*env.current (), alice, gw, USD, boost::none,
+                STPath (), true, false, env.app ().logs ().journal ("Flow"));
             expect (r.first == tesSUCCESS);
             expect (equal (r.second, D{alice, gw, usdC}));
         }
@@ -687,7 +687,7 @@ struct Flow_test : public beast::unit_test::suite
                 }
 
                 return flow (sb, deliver, alice, carol, paths, false, false, true,
-                    boost::none, smax, flowJournal);
+                    false, boost::none, smax, flowJournal);
             }();
 
             expect (flowResult.removableOffers.size () == 1);

--- a/src/ripple/app/tests/Flow_test.cpp
+++ b/src/ripple/app/tests/Flow_test.cpp
@@ -181,7 +181,7 @@ struct Flow_test : public beast::unit_test::suite
             boost::optional<Issue> const& sendMaxIssue, STPath const& path,
             TER expTer, auto&&... expSteps)
         {
-            auto r = toStrand (*env.current (), alice, bob, deliver,
+            auto r = toStrand (*env.current (), alice, bob, deliver, boost::none,
                 sendMaxIssue, path, true, false, env.app ().logs ().journal ("Flow"));
             expect (r.first == expTer);
             if (sizeof...(expSteps))
@@ -236,20 +236,23 @@ struct Flow_test : public beast::unit_test::suite
                 {
                     // The root account can't be the dst
                     auto r = toStrand (*env.current (), alice, xrpAccount (),
-                        XRP, USD.issue (), STPath (), true, false, flowJournal);
+                        XRP, boost::none, USD.issue (), STPath (), true,
+                        false, flowJournal);
                     expect (r.first == temBAD_PATH);
                 }
                 {
                     // The root account can't be the src
                     auto r =
                         toStrand (*env.current (), xrpAccount (), alice,
-                            XRP, boost::none, STPath (), true, false, flowJournal);
+                            XRP, boost::none, boost::none, STPath (), true,
+                            false, flowJournal);
                     expect (r.first == temBAD_PATH);
                 }
                 {
                     // The root account can't be the src
                     auto r = toStrand (*env.current (), noAccount (),
-                        bob, USD, boost::none, STPath (), true, false, flowJournal);
+                        bob, USD, boost::none, boost::none, STPath (), true,
+                        false, flowJournal);
                     expect (r.first == terNO_ACCOUNT);
                 }
             }
@@ -359,7 +362,8 @@ struct Flow_test : public beast::unit_test::suite
 
             // Check pure issue redeem still works
             auto r = toStrand (*env.current (), alice, gw, USD, boost::none,
-                STPath (), true, false, env.app ().logs ().journal ("Flow"));
+                boost::none, STPath (), true, false,
+                env.app ().logs ().journal ("Flow"));
             expect (r.first == tesSUCCESS);
             expect (equal (r.second, D{alice, gw, usdC}));
         }

--- a/src/ripple/app/tests/Offer.test.cpp
+++ b/src/ripple/app/tests/Offer.test.cpp
@@ -24,6 +24,7 @@
 #include <ripple/test/jtx.h>
 #include <ripple/test/jtx/Account.h>
 #include <ripple/ledger/tests/PathSet.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/SystemParameters.h>
 
 namespace ripple {
@@ -233,25 +234,13 @@ public:
                     return STAmountSO::soTime2 - delta;
             }();
 
-            auto offerCount = [&env](jtx::Account const& account)
-            {
-                auto count = 0;
-                forEachItem (*env.current (), account,
-                    [&](std::shared_ptr<SLE const> const& sle)
-                    {
-                        if (sle->getType () == ltOFFER)
-                            ++count;
-                    });
-                return count;
-            };
-
             env.fund (XRP (10000), alice, bob, carol, dan, erin, gw);
             env.trust (USD (1000), alice, bob, carol, dan, erin);
             env (pay (gw, carol, USD (0.99999)));
             env (pay (gw, dan, USD (1)));
             env (pay (gw, erin, USD (1)));
 
-            // Carol doen't quite have enough funds for this offer
+            // Carol doesn't quite have enough funds for this offer
             // The amount left after this offer is taken will cause
             // STAmount to incorrectly round to zero when the next offer
             // (at a good quality) is considered. (when the
@@ -275,20 +264,23 @@ public:
                     sendmax (XRP (102)),
                     txflags (tfNoRippleDirect | tfPartialPayment));
 
-                expect (offerCount (carol) == 0);
-                expect (offerCount (dan) == 1);
+                env.require (
+                    offers (carol, 0),
+                    offers (dan, 1));
                 if (!withFix)
                 {
                     // funded offer was removed
-                    expect (offerCount (erin) == 0);
-                    env.require (balance ("erin", USD (1)));
+                    env.require (
+                        balance ("erin", USD (1)),
+                        offers (erin, 0));
                 }
                 else
                 {
-                    // offer was correctly consumed. There is stil some
+                    // offer was correctly consumed. There is still some
                     // liquidity left on that offer.
-                    expect (offerCount (erin) == 1);
-                    env.require (balance ("erin", USD (0.99999)));
+                    env.require (
+                        balance ("erin", USD (0.99999)),
+                        offers (erin, 1));
                 }
             }
         }
@@ -460,6 +452,20 @@ public:
         }
     }
 
+    // Helper function that returns the Offers on an account.
+    static std::vector<std::shared_ptr<SLE const>>
+    offersOnAccount (jtx::Env& env, jtx::Account account)
+    {
+        std::vector<std::shared_ptr<SLE const>> result;
+        forEachItem (*env.current (), account,
+            [&env, &result](std::shared_ptr<SLE const> const& sle)
+            {
+                if (sle->getType() == ltOFFER)
+                     result.push_back (sle);
+            });
+        return result;
+    }
+
     void
     testFillModes ()
     {
@@ -565,6 +571,62 @@ public:
                 balance ("bob", USD(100)),
                 owners ("bob", 1),
                 offers ("bob", 0));
+        }
+
+        // tfPassive -- place the offer without crossing it.
+        {
+            Env env(*this);
+            env.fund (startBalance, gw);
+
+            auto const f = env.current ()->fees ().base;
+
+            env.fund (startBalance, "alice", "bob");
+            env.close();
+
+            env (trust ("bob", USD(1000)));
+            env.close();
+
+            env (pay (gw, "bob", USD(1000)));
+            env.close();
+
+            env (offer ("alice", USD(1000), XRP(2000)));
+            env.close();
+
+            auto const aliceOffers = offersOnAccount (env, "alice");
+            expect (aliceOffers.size() == 1);
+            for (auto offerPtr : aliceOffers)
+            {
+                auto const& offer = *offerPtr;
+                expect (offer[sfTakerGets] == XRP (2000));
+                expect (offer[sfTakerPays] == USD (1000));
+            }
+
+            // bob creates a passive offer that could cross alice's.
+            // bob's offer should stay in the ledger.
+            env (offer ("bob", XRP(2000), USD(1000), tfPassive));
+            env.close();
+            env.require (offers ("alice", 1));
+
+            auto const bobOffers = offersOnAccount (env, "bob");
+            expect (bobOffers.size() == 1);
+            for (auto offerPtr : bobOffers)
+            {
+                auto const& offer = *offerPtr;
+                expect (offer[sfTakerGets] == USD (1000));
+                expect (offer[sfTakerPays] == XRP (2000));
+            }
+
+            // It should be possible for gw to cross both of those offers.
+            env (offer (gw, XRP(2000), USD(1000)));
+            env.close();
+            env.require (offers ("alice", 0));
+            env.require (offers ("gw", 0));
+            env.require (offers ("bob", 1));
+
+            env (offer (gw, USD(1000), XRP(2000)));
+            env.close();
+            env.require (offers ("bob", 0));
+            env.require (offers ("gw", 0));
         }
     }
 
@@ -727,13 +789,200 @@ public:
             balance ("alice", startBalance - f - f - f),
             balance ("alice", usdOffer),
             offers ("alice", 0),
-            owners ("alice", 1),
+            owners ("alice", 1));
+        env.require (
             balance ("bob", startBalance - f),
             balance ("bob", USD(none)),
             offers ("bob", 1),
             owners ("bob", 1));
     }
 
+    // Helper function that validates a *defaulted* trustline.  If the
+    // trustline is not defaulted then the tests will not pass.
+    void
+    verifyDefaultTrustline (jtx::Env& env,
+        jtx::Account const& account, jtx::PrettyAmount const& expectBalance)
+    {
+        auto const sleTrust =
+            env.le (keylet::line(account.id(), expectBalance.value().issue()));
+        expect (sleTrust);
+        if (sleTrust)
+        {
+            Issue const issue = expectBalance.value().issue();
+            bool const accountLow = account.id() < issue.account;
+
+            STAmount low (issue);
+            STAmount high (issue);
+
+            low.setIssuer (accountLow ? account.id() : issue.account);
+            high.setIssuer (accountLow ? issue.account : account.id());
+
+            expect (sleTrust->getFieldAmount (sfLowLimit) == low);
+            expect (sleTrust->getFieldAmount (sfHighLimit) == high);
+
+            STAmount actualBalance = sleTrust->getFieldAmount (sfBalance);
+            if (! accountLow)
+                actualBalance.negate();
+
+            expect (actualBalance == expectBalance);
+        }
+    }
+
+    void testPartialCross()
+    {
+        // Test a number of different corner cases regarding adding a
+        // possibly crossable offer to an account.  The test is table
+        // driven so it should be easy to add or remove tests.
+        testcase ("Partial Crossing");
+
+        using namespace jtx;
+
+        auto const gw = Account("gateway");
+        auto const USD = gw["USD"];
+
+        Env env(*this);
+        env.fund (XRP(10000000), gw);
+
+        // The fee that's charged for transactions
+        auto const f = env.current ()->fees ().base;
+
+        // To keep things simple all offers are 1 : 1 for XRP : USD.
+        enum preTrustType {noPreTrust, gwPreTrust, acctPreTrust};
+        struct TestData
+        {
+            std::string account;       // Account operated on
+            STAmount fundXrp;          // Account funded with
+            int bookAmount;            // USD -> XRP offer on the books
+            preTrustType preTrust;     // If true, pre-establish trust line
+            int offerAmount;           // Account offers this much XRP -> USD
+            TER tec;                   // Returned tec code
+            STAmount spentXrp;         // Amount removed from fundXrp
+            PrettyAmount balanceUsd;   // Balance on account end
+            int offers;                // Offers on account
+            int owners;                // Owners on account
+        };
+
+        TestData const tests[]
+        {
+//acct                             fundXrp  bookAmt      preTrust  offerAmt                     tec       spentXrp    balanceUSD  offers  owners
+{"ann",             reserve (env, 0) + 0*f,       1,   noPreTrust,     1000,      tecUNFUNDED_OFFER,             f, USD(      0),      0,     0}, // Account is at the reserve, and will dip below once fees are subtracted.
+{"bev",             reserve (env, 0) + 1*f,       1,   noPreTrust,     1000,      tecUNFUNDED_OFFER,             f, USD(      0),      0,     0}, // Account has just enough for the reserve and the fee.
+{"cam",             reserve (env, 0) + 2*f,       0,   noPreTrust,     1000, tecINSUF_RESERVE_OFFER,             f, USD(      0),      0,     0}, // Account has enough for the reserve, the fee and the offer, and a bit more, but not enough for the reserve after the offer is placed.
+{"deb",             reserve (env, 0) + 2*f,       1,   noPreTrust,     1000,             tesSUCCESS,           2*f, USD(0.00001),      0,     1}, // Account has enough to buy a little USD then the offer runs dry.
+{"eve",             reserve (env, 1) + 0*f,       0,   noPreTrust,     1000,             tesSUCCESS,             f, USD(      0),      1,     1}, // No offer to cross
+{"flo",             reserve (env, 1) + 0*f,       1,   noPreTrust,     1000,             tesSUCCESS, XRP(   1) + f, USD(      1),      0,     1},
+{"gay",             reserve (env, 1) + 1*f,    1000,   noPreTrust,     1000,             tesSUCCESS, XRP(  50) + f, USD(     50),      0,     1},
+{"hye", XRP(1000)                    + 1*f,    1000,   noPreTrust,     1000,             tesSUCCESS, XRP( 800) + f, USD(    800),      0,     1},
+{"ivy", XRP(   1) + reserve (env, 1) + 1*f,       1,   noPreTrust,     1000,             tesSUCCESS, XRP(   1) + f, USD(      1),      0,     1},
+{"joy", XRP(   1) + reserve (env, 2) + 1*f,       1,   noPreTrust,     1000,             tesSUCCESS, XRP(   1) + f, USD(      1),      1,     2},
+{"kim", XRP( 900) + reserve (env, 2) + 1*f,     999,   noPreTrust,     1000,             tesSUCCESS, XRP( 999) + f, USD(    999),      0,     1},
+{"liz", XRP( 998) + reserve (env, 0) + 1*f,     999,   noPreTrust,     1000,             tesSUCCESS, XRP( 998) + f, USD(    998),      0,     1},
+{"meg", XRP( 998) + reserve (env, 1) + 1*f,     999,   noPreTrust,     1000,             tesSUCCESS, XRP( 999) + f, USD(    999),      0,     1},
+{"nia", XRP( 998) + reserve (env, 2) + 1*f,     999,   noPreTrust,     1000,             tesSUCCESS, XRP( 999) + f, USD(    999),      1,     2},
+{"ova", XRP( 999) + reserve (env, 0) + 1*f,    1000,   noPreTrust,     1000,             tesSUCCESS, XRP( 999) + f, USD(    999),      0,     1},
+{"pam", XRP( 999) + reserve (env, 1) + 1*f,    1000,   noPreTrust,     1000,             tesSUCCESS, XRP(1000) + f, USD(   1000),      0,     1},
+{"rae", XRP( 999) + reserve (env, 2) + 1*f,    1000,   noPreTrust,     1000,             tesSUCCESS, XRP(1000) + f, USD(   1000),      0,     1},
+{"sue", XRP(1000) + reserve (env, 2) + 1*f,       0,   noPreTrust,     1000,             tesSUCCESS,             f, USD(      0),      1,     1},
+
+//---------------------Pre-established trust lines -----------------------------
+{"abe",             reserve (env, 0) + 0*f,       1,   gwPreTrust,     1000,      tecUNFUNDED_OFFER,             f, USD(      0),      0,     0},
+{"bud",             reserve (env, 0) + 1*f,       1,   gwPreTrust,     1000,      tecUNFUNDED_OFFER,             f, USD(      0),      0,     0},
+{"che",             reserve (env, 0) + 2*f,       0,   gwPreTrust,     1000, tecINSUF_RESERVE_OFFER,             f, USD(      0),      0,     0},
+{"dan",             reserve (env, 0) + 2*f,       1,   gwPreTrust,     1000,             tesSUCCESS,           2*f, USD(0.00001),      0,     0},
+{"eli", XRP(  20) + reserve (env, 0) + 1*f,    1000,   gwPreTrust,     1000,             tesSUCCESS, XRP(20) + 1*f, USD(     20),      0,     0},
+{"fee",             reserve (env, 1) + 0*f,       0,   gwPreTrust,     1000,             tesSUCCESS,             f, USD(      0),      1,     1},
+{"gar",             reserve (env, 1) + 0*f,       1,   gwPreTrust,     1000,             tesSUCCESS, XRP(   1) + f, USD(      1),      1,     1},
+{"hal",             reserve (env, 1) + 1*f,       1,   gwPreTrust,     1000,             tesSUCCESS, XRP(   1) + f, USD(      1),      1,     1},
+
+{"ned",             reserve (env, 1) + 0*f,       1, acctPreTrust,     1000,      tecUNFUNDED_OFFER,           2*f, USD(      0),      0,     1},
+{"ole",             reserve (env, 1) + 1*f,       1, acctPreTrust,     1000,      tecUNFUNDED_OFFER,           2*f, USD(      0),      0,     1},
+{"pat",             reserve (env, 1) + 2*f,       0, acctPreTrust,     1000,      tecUNFUNDED_OFFER,           2*f, USD(      0),      0,     1},
+{"quy",             reserve (env, 1) + 2*f,       1, acctPreTrust,     1000,      tecUNFUNDED_OFFER,           2*f, USD(      0),      0,     1},
+{"ron",             reserve (env, 1) + 3*f,       0, acctPreTrust,     1000, tecINSUF_RESERVE_OFFER,           2*f, USD(      0),      0,     1},
+{"syd",             reserve (env, 1) + 3*f,       1, acctPreTrust,     1000,             tesSUCCESS,           3*f, USD(0.00001),      0,     1},
+{"ted", XRP(  20) + reserve (env, 1) + 2*f,    1000, acctPreTrust,     1000,             tesSUCCESS, XRP(20) + 2*f, USD(     20),      0,     1},
+{"uli",             reserve (env, 2) + 0*f,       0, acctPreTrust,     1000, tecINSUF_RESERVE_OFFER,           2*f, USD(      0),      0,     1},
+{"vic",             reserve (env, 2) + 0*f,       1, acctPreTrust,     1000,             tesSUCCESS, XRP( 1) + 2*f, USD(      1),      0,     1},
+{"wes",             reserve (env, 2) + 1*f,       0, acctPreTrust,     1000,             tesSUCCESS,           2*f, USD(      0),      1,     2},
+{"xan",             reserve (env, 2) + 1*f,       1, acctPreTrust,     1000,             tesSUCCESS, XRP( 1) + 2*f, USD(      1),      1,     2},
+};
+
+        for (auto const& t : tests)
+        {
+            auto const acct = Account(t.account);
+            env.fund (t.fundXrp, acct);
+            env.close();
+
+            // Make sure gateway has no current offers.
+            env.require (offers (gw, 0));
+
+            // The gateway optionally creates an offer that would be crossed.
+            auto const book = t.bookAmount;
+            if (book)
+                env (offer (gw, XRP (book), USD (book)));
+            env.close();
+            std::uint32_t const gwOfferSeq = env.seq (gw) - 1;
+
+            // Optionally pre-establish a trustline between gw and acct.
+            if (t.preTrust == gwPreTrust)
+                env (trust (gw, acct["USD"] (1)));
+
+            // Optionally pre-establish a trustline between acct and gw.
+            // Note this is not really part of the test, so we expect there
+            // to be enough XRP reserve for acct to create the trust line.
+            if (t.preTrust == acctPreTrust)
+                env (trust (acct, USD (1)));
+
+            env.close();
+
+            // Acct creates an offer.  This is the heart of the test.
+            auto const acctOffer = t.offerAmount;
+            env (offer (acct, USD (acctOffer), XRP (acctOffer)), ter (t.tec));
+            env.close();
+            std::uint32_t const acctOfferSeq = env.seq (acct) - 1;
+
+            expect (env.balance (acct, USD.issue()) == t.balanceUsd);
+            expect (env.balance (acct, xrpIssue()) == t.fundXrp - t.spentXrp);
+            env.require (offers (acct, t.offers));
+            env.require (owners (acct, t.owners));
+
+            auto acctOffers = offersOnAccount (env, acct);
+            expect (acctOffers.size() == t.offers);
+            if (acctOffers.size() && t.offers)
+            {
+                auto const& acctOffer = *(acctOffers.front());
+
+                auto const leftover = t.offerAmount - t.bookAmount;
+                expect (acctOffer[sfTakerGets] == XRP (leftover));
+                expect (acctOffer[sfTakerPays] == USD (leftover));
+            }
+
+            if (t.preTrust == noPreTrust)
+            {
+                if (t.balanceUsd.value().signum())
+                {
+                    // Verify the correct contents of the trustline
+                    verifyDefaultTrustline (env, acct, t.balanceUsd);
+                }
+                else
+                {
+                    // Verify that no trustline was created.
+                    auto const sleTrust =
+                        env.le (keylet::line(acct, USD.issue()));
+                    expect (! sleTrust);
+                }
+            }
+
+            // Give the next loop a clean slate by canceling any left-overs
+            // in the offers.
+            env (offer_cancel (acct, acctOfferSeq));
+            env (offer_cancel (gw, gwOfferSeq));
+            env.close();
+        }
+    }
+
+    // I believe that the cases in the previous test covers all of these
+    // tests.  Do you agree?????
     void
     testUnfundedCross()
     {
@@ -759,6 +1008,7 @@ public:
         env (offer ("alice", usdOffer, xrpOffer),     ter(tecUNFUNDED_OFFER));
         env.require (
             balance ("alice", reserve (env, 0) - f),
+            offers ("alice", 0),
             owners ("alice", 0));
 
         // Account has just enough for the reserve and the
@@ -767,6 +1017,7 @@ public:
         env (offer ("bob", usdOffer, xrpOffer),       ter(tecUNFUNDED_OFFER));
         env.require (
             balance ("bob", reserve (env, 0)),
+            offers ("bob", 0),
             owners ("bob", 0));
 
         // Account has enough for the reserve, the fee and
@@ -776,6 +1027,7 @@ public:
         env (offer ("carol", usdOffer, xrpOffer),     ter(tecINSUF_RESERVE_OFFER));
         env.require (
             balance ("carol", reserve (env, 0) + XRP(1)),
+            offers ("carol", 0),
             owners ("carol", 0));
 
         // Account has enough for the reserve plus one
@@ -784,15 +1036,680 @@ public:
         env (offer ("dan", usdOffer, xrpOffer),       ter(tesSUCCESS));
         env.require (
             balance ("dan", reserve (env, 1)),
+            offers ("dan", 1),
             owners ("dan", 1));
 
         // Account has enough for the reserve plus one
-        // offer, the fee and the entire offer amount.
+        // offer, the fee and part of the offer amount.
         env.fund (reserve (env, 1) + f + xrpOffer, "eve");
         env (offer ("eve", usdOffer, xrpOffer),       ter(tesSUCCESS));
         env.require (
             balance ("eve", reserve (env, 1) + xrpOffer),
+            offers ("eve", 1),
             owners ("eve", 1));
+    }
+
+    void
+    testXRPDirectCross()
+    {
+        testcase ("XRP Direct Crossing");
+
+        using namespace jtx;
+
+        auto const gw = Account("gateway");
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const USD = gw["USD"];
+
+        auto const usdOffer = USD(1000);
+        auto const xrpOffer = XRP(1000);
+
+        Env env(*this);
+        env.fund (XRP(1000000), gw, bob);
+        env.close();
+
+        // The fee that's charged for transactions.
+        auto const fee = env.current ()->fees ().base;
+
+        // alice's account has enough for the reserve, one trust line plus two
+        // offers, and two fees.
+        env.fund (reserve (env, 2) + (fee * 2), alice);
+        env.close();
+
+        env (trust(alice, usdOffer));
+
+        env.close();
+
+        env (pay(gw, alice, usdOffer));
+        env.close();
+        env.require (
+            balance (alice, usdOffer),
+            offers (alice, 0),
+            offers (bob, 0));
+
+        // The scenario:
+        //   o alice has USD but wants XRP.
+        //   o bob has XRP but wants USD.
+        auto const alicesXRP = env.balance (alice);
+        auto const bobsXRP = env.balance (bob);
+
+        env (offer (alice, xrpOffer, usdOffer));
+        env.close();
+        env (offer (bob, usdOffer, xrpOffer));
+
+        env.close();
+        env.require (
+            balance (alice, USD(0)),
+            balance (bob, usdOffer),
+            balance (alice, alicesXRP + xrpOffer - fee),
+            balance (bob,   bobsXRP   - xrpOffer - fee),
+            offers (alice, 0),
+            offers (bob, 0));
+
+        verifyDefaultTrustline (env, bob, usdOffer);
+
+        // Make two more offers that leave one of the offers non-dry.
+        env (offer (alice, USD(999), XRP(999)));
+        env (offer (bob, xrpOffer, usdOffer));
+
+        env.close();
+        env.require (balance (alice, USD(999)));
+        env.require (balance (bob, USD(1)));
+        env.require (offers (alice, 0));
+        verifyDefaultTrustline (env, bob, USD(1));
+        {
+            auto bobsOffers = offersOnAccount (env, bob);
+            expect (bobsOffers.size() == 1);
+            auto const& bobsOffer = *(bobsOffers.front());
+
+            expect (bobsOffer[sfLedgerEntryType] == ltOFFER);
+            expect (bobsOffer[sfTakerGets] == USD (1));
+            expect (bobsOffer[sfTakerPays] == XRP (1));
+        }
+   }
+
+    void
+    testDirectCross()
+    {
+        testcase ("Direct Crossing");
+
+        using namespace jtx;
+
+        auto const gw = Account("gateway");
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const USD = gw["USD"];
+        auto const EUR = gw["EUR"];
+
+        auto const usdOffer = USD(1000);
+        auto const eurOffer = EUR(1000);
+
+        Env env(*this);
+        env.fund (XRP(1000000), gw);
+        env.close();
+
+        // The fee that's charged for transactions.
+        auto const fee = env.current ()->fees ().base;
+
+        // Each account has enough for the reserve, two trust lines, one
+        // offer, and two fees.
+        env.fund (reserve (env, 3) + (fee * 3), alice);
+        env.fund (reserve (env, 3) + (fee * 2), bob);
+        env.close();
+        env (trust(alice, usdOffer));
+        env (trust(bob, eurOffer));
+        env.close();
+
+        env (pay(gw, alice, usdOffer));
+        env (pay(gw, bob, eurOffer));
+        env.close();
+        env.require (
+            balance (alice, usdOffer),
+            balance (bob, eurOffer));
+
+        // The scenario:
+        //   o alice has USD but wants EUR.
+        //   o bob has EUR but wants USD.
+        env (offer (alice, eurOffer, usdOffer));
+        env (offer (bob, usdOffer, eurOffer));
+
+        env.close();
+        env.require (
+            balance (alice, eurOffer),
+            balance (bob, usdOffer),
+            offers (alice, 0),
+            offers (bob, 0));
+        verifyDefaultTrustline (env, alice, eurOffer);
+        verifyDefaultTrustline (env, bob, usdOffer);
+
+        // Make two more offers that leave one of the offers non-dry.
+        env (offer (alice, USD(999), eurOffer));
+        env (offer (bob, eurOffer, usdOffer));
+
+        env.close();
+        env.require (
+            balance (alice, USD(999)),
+            balance (alice, EUR(1)),
+            balance (bob, USD(1)),
+            balance (bob, EUR(999)),
+            offers (alice, 0));
+        verifyDefaultTrustline (env, alice, EUR(1));
+        verifyDefaultTrustline (env, bob, USD(1));
+        {
+            auto bobsOffers = offersOnAccount (env, bob);
+            expect (bobsOffers.size() == 1);
+            auto const& bobsOffer = *(bobsOffers.front());
+
+            expect (bobsOffer[sfTakerGets] == USD (1));
+            expect (bobsOffer[sfTakerPays] == EUR (1));
+        }
+
+        // alice makes one more offer that cleans out bob's offer.
+        env (offer (alice, USD(1), EUR(1)));
+
+        env.close();
+        env.require (balance (alice, USD(1000)));
+        env.require (balance (alice, EUR(none)));
+        env.require (balance (bob, USD(none)));
+        env.require (balance (bob, EUR(1000)));
+        env.require (offers (alice, 0));
+        env.require (offers (bob, 0));
+
+        // The two trustlines that were generated by offers should be gone.
+        expect (! env.le (keylet::line (alice.id(), EUR.issue())));
+        expect (! env.le (keylet::line (bob.id(), USD.issue())));
+    }
+
+    void
+    testBridgedCross()
+    {
+        testcase ("Bridged Crossing");
+
+        using namespace jtx;
+
+        auto const gw    = Account("gateway");
+        auto const alice = Account("alice");
+        auto const bob   = Account("bob");
+        auto const carol = Account("carol");
+        auto const USD = gw["USD"];
+        auto const EUR = gw["EUR"];
+
+        auto const usdOffer = USD(1000);
+        auto const eurOffer = EUR(1000);
+
+        Env env(*this);
+
+        env.fund (XRP(1000000), gw, alice, bob, carol);
+        env.close();
+
+        env (trust(alice, usdOffer));
+        env (trust(carol, eurOffer));
+        env.close();
+        env (pay(gw, alice, usdOffer));
+        env (pay(gw, carol, eurOffer));
+        env.close();
+
+        // The scenario:
+        //   o alice has USD but wants XPR.
+        //   o bob has XRP but wants EUR.
+        //   o carol has EUR but wants USD.
+        // Note that carol's offer must come last.  If carol's offer is placed
+        // before bob's or alice's, then autobridging will not occur.
+        env (offer (alice, XRP(1000), usdOffer));
+        env (offer (bob, eurOffer, XRP(1000)));
+        auto const bobXrpBalance = env.balance (bob);
+        env.close();
+
+        // carol makes an offer that partially consumes alice and bob's offers.
+        env (offer (carol, USD(400), EUR(400)));
+        env.close();
+
+        env.require (
+            balance (alice, USD(600)),
+            balance (bob,   EUR(400)),
+            balance (carol, USD(400)),
+            balance (bob, bobXrpBalance - XRP(400)),
+            offers (carol, 0));
+        verifyDefaultTrustline (env, bob, EUR(400));
+        verifyDefaultTrustline (env, carol, USD(400));
+        {
+            auto const alicesOffers = offersOnAccount (env, alice);
+            expect (alicesOffers.size() == 1);
+            auto const& alicesOffer = *(alicesOffers.front());
+
+            expect (alicesOffer[sfLedgerEntryType] == ltOFFER);
+            expect (alicesOffer[sfTakerGets] == USD (600));
+            expect (alicesOffer[sfTakerPays] == XRP (600));
+        }
+        {
+            auto const bobsOffers = offersOnAccount (env, bob);
+            expect (bobsOffers.size() == 1);
+            auto const& bobsOffer = *(bobsOffers.front());
+
+            expect (bobsOffer[sfLedgerEntryType] == ltOFFER);
+            expect (bobsOffer[sfTakerGets] == XRP (600));
+            expect (bobsOffer[sfTakerPays] == EUR (600));
+        }
+
+        // carol makes an offer that exactly consumes alice and bob's offers.
+        env (offer (carol, USD(600), EUR(600)));
+        env.close();
+
+        env.require (
+            balance (alice, USD(0)),
+            balance (bob, eurOffer),
+            balance (carol, usdOffer),
+            balance (bob, bobXrpBalance - XRP(1000)),
+            offers (bob, 0),
+            offers (carol, 0));
+        verifyDefaultTrustline (env, bob, EUR(1000));
+        verifyDefaultTrustline (env, carol, USD(1000));
+
+        // In pre-flow code alice's offer is left empty in the ledger.
+        auto const alicesOffers = offersOnAccount (env, alice);
+        if (alicesOffers.size() != 0)
+        {
+            expect (alicesOffers.size() == 1);
+            auto const& alicesOffer = *(alicesOffers.front());
+
+            expect (alicesOffer[sfLedgerEntryType] == ltOFFER);
+            expect (alicesOffer[sfTakerGets] == USD (0));
+            expect (alicesOffer[sfTakerPays] == XRP (0));
+        }
+    }
+
+    void
+    testSellOffer()
+    {
+        // Test a number of different corner cases regarding offer crossing
+        // when the tfSell flag is set.  The test is table driven so it
+        // should be easy to add or remove tests.
+        testcase ("Sell Offer");
+
+        using namespace jtx;
+
+        auto const gw = Account("gateway");
+        auto const USD = gw["USD"];
+
+        Env env(*this);
+        env.fund (XRP(10000000), gw);
+
+        // The fee that's charged for transactions
+        auto const f = env.current ()->fees ().base;
+
+        // To keep things simple all offers are 1 : 1 for XRP : USD.
+        enum preTrustType {noPreTrust, gwPreTrust, acctPreTrust};
+        struct TestData
+        {
+            std::string account;       // Account operated on
+            STAmount fundXrp;          // XRP acct funded with
+            STAmount fundUSD;          // USD acct funded with
+            STAmount gwGets;           // gw's offer
+            STAmount gwPays;           //
+            STAmount acctGets;         // acct's offer
+            STAmount acctPays;         //
+            TER tec;                   // Returned tec code
+            STAmount spentXrp;         // Amount removed from fundXrp
+            STAmount finalUsd;         // Final USD balance on acct
+            int offers;                // Offers on acct
+            int owners;                // Owners on acct
+            STAmount takerGets;        // Remainder of acct's offer
+            STAmount takerPays;        //
+
+            // Constructor with takerGets/takerPays
+            TestData (
+                std::string&& account_,         // Account operated on
+                STAmount const& fundXrp_,       // XRP acct funded with
+                STAmount const& fundUSD_,       // USD acct funded with
+                STAmount const& gwGets_,        // gw's offer
+                STAmount const& gwPays_,        //
+                STAmount const& acctGets_,      // acct's offer
+                STAmount const& acctPays_,      //
+                TER tec_,                       // Returned tec code
+                STAmount const& spentXrp_,      // Amount removed from fundXrp
+                STAmount const& finalUsd_,      // Final USD balance on acct
+                int offers_,                    // Offers on acct
+                int owners_,                    // Owners on acct
+                STAmount const& takerGets_,     // Remainder of acct's offer
+                STAmount const& takerPays_)     //
+                : account (std::move(account_))
+                , fundXrp (fundXrp_)
+                , fundUSD (fundUSD_)
+                , gwGets (gwGets_)
+                , gwPays (gwPays_)
+                , acctGets (acctGets_)
+                , acctPays (acctPays_)
+                , tec (tec_)
+                , spentXrp (spentXrp_)
+                , finalUsd (finalUsd_)
+                , offers (offers_)
+                , owners (owners_)
+                , takerGets (takerGets_)
+                , takerPays (takerPays_)
+            { }
+
+            // Constructor without takerGets/takerPays
+            TestData (
+                std::string&& account_,         // Account operated on
+                STAmount const& fundXrp_,       // XRP acct funded with
+                STAmount const& fundUSD_,       // USD acct funded with
+                STAmount const& gwGets_,        // gw's offer
+                STAmount const& gwPays_,        //
+                STAmount const& acctGets_,      // acct's offer
+                STAmount const& acctPays_,      //
+                TER tec_,                       // Returned tec code
+                STAmount const& spentXrp_,      // Amount removed from fundXrp
+                STAmount const& finalUsd_,      // Final USD balance on acct
+                int offers_,                    // Offers on acct
+                int owners_)                    // Owners on acct
+                : TestData (std::move(account_), fundXrp_, fundUSD_, gwGets_,
+                  gwPays_, acctGets_, acctPays_, tec_, spentXrp_, finalUsd_,
+                  offers_, owners_, STAmount::saZero, STAmount::saZero)
+            { }
+        };
+
+        TestData const tests[]
+        {
+// acct pays XRP
+//acct                           fundXrp  fundUSD   gwGets   gwPays  acctGets  acctPays                      tec         spentXrp  finalUSD  offers  owners  takerGets  takerPays
+{"ann", XRP(10) + reserve (env, 0) + 1*f, USD( 0), XRP(10), USD( 5),  USD(10),  XRP(10), tecINSUF_RESERVE_OFFER, XRP( 0) + (1*f),  USD( 0),      0,     0},
+{"bev", XRP(10) + reserve (env, 1) + 1*f, USD( 0), XRP(10), USD( 5),  USD(10),  XRP(10),             tesSUCCESS, XRP( 0) + (1*f),  USD( 0),      1,     1,     XRP(10),  USD(10)},
+{"cam", XRP(10) + reserve (env, 0) + 1*f, USD( 0), XRP(10), USD(10),  USD(10),  XRP(10),             tesSUCCESS, XRP(10) + (1*f),  USD(10),      0,     1},
+{"deb", XRP(10) + reserve (env, 0) + 1*f, USD( 0), XRP(10), USD(20),  USD(10),  XRP(10),             tesSUCCESS, XRP(10) + (1*f),  USD(20),      0,     1},
+{"eve", XRP(10) + reserve (env, 0) + 1*f, USD( 0), XRP(10), USD(20),  USD( 5),  XRP( 5),             tesSUCCESS, XRP( 5) + (1*f),  USD(10),      0,     1},
+{"flo", XRP(10) + reserve (env, 0) + 1*f, USD( 0), XRP(10), USD(20),  USD(20),  XRP(20),             tesSUCCESS, XRP(10) + (1*f),  USD(20),      0,     1},
+{"gay", XRP(20) + reserve (env, 1) + 1*f, USD( 0), XRP(10), USD(20),  USD(20),  XRP(20),             tesSUCCESS, XRP(10) + (1*f),  USD(20),      0,     1},
+{"hye", XRP(20) + reserve (env, 2) + 1*f, USD( 0), XRP(10), USD(20),  USD(20),  XRP(20),             tesSUCCESS, XRP(10) + (1*f),  USD(20),      1,     2,     XRP(10),  USD(10)},
+// acct pays USD
+{"meg",           reserve (env, 1) + 2*f, USD(10), USD(10), XRP( 5),  XRP(10),  USD(10), tecINSUF_RESERVE_OFFER, XRP(  0) + (2*f),  USD(10),      0,     1},
+{"nia",           reserve (env, 2) + 2*f, USD(10), USD(10), XRP( 5),  XRP(10),  USD(10),             tesSUCCESS, XRP(  0) + (2*f),  USD(10),      1,     2,     USD(10),  XRP(10)},
+{"ova",           reserve (env, 1) + 2*f, USD(10), USD(10), XRP(10),  XRP(10),  USD(10),             tesSUCCESS, XRP(-10) + (2*f),  USD( 0),      0,     1},
+{"pam",           reserve (env, 1) + 2*f, USD(10), USD(10), XRP(20),  XRP(10),  USD(10),             tesSUCCESS, XRP(-20) + (2*f),  USD( 0),      0,     1},
+{"qui",           reserve (env, 1) + 2*f, USD(10), USD(20), XRP(40),  XRP(10),  USD(10),             tesSUCCESS, XRP(-20) + (2*f),  USD( 0),      0,     1},
+{"rae",           reserve (env, 2) + 2*f, USD(10), USD( 5), XRP( 5),  XRP(10),  USD(10),             tesSUCCESS, XRP( -5) + (2*f),  USD( 5),      1,     2,     USD( 5),  XRP( 5)},
+{"sue",           reserve (env, 2) + 2*f, USD(10), USD( 5), XRP(10),  XRP(10),  USD(10),             tesSUCCESS, XRP(-10) + (2*f),  USD( 5),      1,     2,     USD( 5),  XRP( 5)},
+};
+        auto const zeroUsd = USD(0);
+        for (auto const& t : tests)
+        {
+            // Make sure gateway has no current offers.
+            env.require (offers (gw, 0));
+
+            auto const acct = Account(t.account);
+
+            env.fund (t.fundXrp, acct);
+            env.close();
+
+            // Optionally give acct some USD.  This is not part of the test,
+            // so we assume that acct has sufficient USD to cover the reserve
+            // on the trust line.
+            if (t.fundUSD != zeroUsd)
+            {
+                env (trust (acct, t.fundUSD));
+                env.close();
+                env (pay (gw, acct, t.fundUSD));
+                env.close();
+            }
+
+            env (offer (gw, t.gwGets, t.gwPays));
+            env.close();
+            std::uint32_t const gwOfferSeq = env.seq (gw) - 1;
+
+            // Acct creates a tfSell offer.  This is the heart of the test.
+            env (offer (acct, t.acctGets, t.acctPays, tfSell), ter (t.tec));
+            env.close();
+            std::uint32_t const acctOfferSeq = env.seq (acct) - 1;
+
+            // Check results
+            expect (env.balance (acct, USD.issue()) == t.finalUsd);
+            expect (env.balance (acct, xrpIssue()) == t.fundXrp - t.spentXrp);
+            env.require (offers (acct, t.offers));
+            env.require (owners (acct, t.owners));
+
+            if (t.offers)
+            {
+                auto const acctOffers = offersOnAccount (env, acct);
+                if (acctOffers.size() > 0)
+                {
+                    expect (acctOffers.size() == 1);
+                    auto const& acctOffer = *(acctOffers.front());
+
+                    expect (acctOffer[sfLedgerEntryType] == ltOFFER);
+                    expect (acctOffer[sfTakerGets] == t.takerGets);
+                    expect (acctOffer[sfTakerPays] == t.takerPays);
+                }
+            }
+
+            // Give the next loop a clean slate by canceling any left-overs
+            // in the offers.
+            env (offer_cancel (acct, acctOfferSeq));
+            env (offer_cancel (gw, gwOfferSeq));
+            env.close();
+        }
+    }
+
+    void
+    testTransferRateOffer()
+    {
+        testcase ("Transfer Rate Offer");
+
+        using namespace jtx;
+
+        auto const gw1 = Account("gateway1");
+        auto const USD = gw1["USD"];
+
+        Env env(*this);
+
+        // The fee that's charged for transactions.
+        auto const fee = env.current ()->fees ().base;
+
+        env.fund (XRP(100000), gw1);
+        env.close();
+
+        env(rate(gw1, 1.25));
+        {
+            auto const alice = Account("alice");
+            auto const bob   = Account("bob");
+            env.fund (XRP(100) + reserve(env, 2) + (fee*2), alice, bob);
+            env.close();
+
+            env (trust(alice, USD(200)));
+            env (trust(bob, USD(200)));
+            env.close();
+
+            env (pay (gw1, bob, USD(125)));
+            env.close();
+
+            // bob offers to sell USD(100) for XRP.  alice takes bob's offer.
+            // Notice that although bob only offered USD(100), USD(125) was
+            // removed from his account due to the gateway fee.
+            //
+            // A comparable payment would look like this:
+            //   env (pay (bob, alice, USD(100)), sendmax(USD(125)))
+            env (offer (bob, XRP(1), USD(100)));
+            env.close();
+
+            env (offer (alice, USD(100), XRP(1)));
+            env.close();
+
+            env.require (balance (alice, USD(100)));
+            env.require (balance (alice, XRP( 99) + reserve(env, 2)));
+            env.require (offers (alice, 0));
+
+            env.require (balance (bob, USD(  0)));
+            env.require (balance (bob, XRP(101) + reserve(env, 2)));
+            env.require (offers (bob, 0));
+        }
+        {
+            // Reverse the order, so the offer in the books is to sell XRP
+            // in return for USD.  Gateway rate should still apply identically.
+            auto const colin = Account("colin");
+            auto const daria = Account("daria");
+            env.fund (XRP(100) + reserve(env, 2) + (fee*2), colin, daria);
+            env.close();
+
+            env (trust(colin, USD(200)));
+            env (trust(daria, USD(200)));
+            env.close();
+
+            env (pay (gw1, daria, USD(125)));
+            env.close();
+
+            env (offer (colin, USD(100), XRP(1)));
+            env.close();
+
+            env (offer (daria, XRP(1), USD(100)));
+            env.close();
+
+            env.require (balance (colin, USD(100)));
+            env.require (balance (colin, XRP( 99) + reserve(env, 2)));
+            env.require (offers (colin, 0));
+
+            env.require (balance (daria, USD(  0)));
+            env.require (balance (daria, XRP(101) + reserve(env, 2)));
+            env.require (offers (daria, 0));
+        }
+        {
+            auto const edith = Account("edith");
+            auto const frank = Account("frank");
+
+            env.fund (XRP(20000) + fee*2, edith, frank);
+            env.close();
+
+            env (trust (edith, USD(1000)));
+            env (trust (frank, USD(1000)));
+            env.close();
+
+            env (pay (gw1, edith, USD(100)));
+            env (pay (gw1, frank, USD(100)));
+            env.close();
+
+            // This test verifies that the amount removed from an offer
+            // accounts for the transfer fee that is removed from the
+            // account but not from the remaining offer.
+            env (offer (edith, USD(10), XRP(4000)));
+            env.close();
+            std::uint32_t const edithOfferSeq = env.seq (edith) - 1;
+
+            env (offer (frank, XRP(2000), USD(5)));
+            env.close();
+
+            env.require (balance (edith, USD(105)));
+            env.require (balance (edith, XRP(18000)));
+            auto const edithsOffers = offersOnAccount (env, edith);
+            expect (edithsOffers.size() == 1);
+            if (edithsOffers.size() != 0)
+            {
+                auto const& edithsOffer = *(edithsOffers.front());
+                expect (edithsOffer[sfLedgerEntryType] == ltOFFER);
+                expect (edithsOffer[sfTakerGets] == XRP (2000));
+                expect (edithsOffer[sfTakerPays] == USD (5));
+            }
+            env (offer_cancel (edith, edithOfferSeq)); // For later tests
+
+            env.require (balance (frank, USD(93.75)));
+            env.require (balance (frank, XRP(22000)));
+            env.require (offers (frank, 0));
+        }
+        // Start messing with two non-native currencies.
+        auto const gw2   = Account("gateway2");
+        auto const EUR = gw2["EUR"];
+
+        env.fund (XRP(100000), gw2);
+        env.close();
+
+        env(rate(gw2, 1.5));
+        {
+            // Remove XRP from the equation.  Give the two currencies two
+            // different transfer rates so we can see both transfer rates
+            // apply in the same transaction.
+            auto const grace = Account("grace");
+            auto const henry = Account("henry");
+            env.fund (reserve(env, 3) + (fee*3), grace, henry);
+            env.close();
+
+            env (trust(grace, USD(200)));
+            env (trust(grace, EUR(200)));
+            env (trust(henry, USD(200)));
+            env (trust(henry, EUR(200)));
+            env.close();
+
+            env (pay (gw1, grace, USD(125)));
+            env (pay (gw2, henry, EUR(150)));
+            env.close();
+
+            env (offer (grace, EUR(100), USD(100)));
+            env.close();
+
+            env (offer (henry, USD(100), EUR(100)));
+            env.close();
+
+            env.require (balance (grace, USD(  0)));
+            env.require (balance (grace, EUR(100)));
+            env.require (balance (grace, reserve(env, 3)));
+            env.require (offers (grace, 0));
+
+            env.require (balance (henry, USD(100)));
+            env.require (balance (henry, EUR(  0)));
+            env.require (balance (henry, reserve(env, 3)));
+            env.require (offers (henry, 0));
+        }
+        {
+            // Make sure things work right when we're auto-bridging as well.
+            auto const irene = Account("irene");
+            auto const jimmy = Account("jimmy");
+            auto const karen = Account("karen");
+            env.fund (XRP(2) + reserve(env, 3) + (fee*3), irene, jimmy, karen);
+            env.close();
+
+            //   o irene has USD but wants XPR.
+            //   o jimmy has XRP but wants EUR.
+            //   o karen has EUR but wants USD.
+            env (trust(irene, USD(200)));
+            env (trust(irene, EUR(200)));
+            env (trust(jimmy, USD(200)));
+            env (trust(jimmy, EUR(200)));
+            env (trust(karen, USD(200)));
+            env (trust(karen, EUR(200)));
+            env.close();
+
+            env (pay (gw1, irene, USD(125)));
+            env (pay (gw2, karen, EUR(150)));
+            env.close();
+
+            env (offer (irene, XRP(2), USD(100)));
+            env (offer (jimmy, EUR(100), XRP(2)));
+            env.close();
+
+            env (offer (karen, USD(100), EUR(100)));
+            env.close();
+
+            env.require (balance (irene, USD(  0)));
+            env.require (balance (irene, EUR(  0)));
+            env.require (balance (irene, XRP(4) + reserve(env, 3)));
+
+            // In pre-flow code irene's offer is left empty in the ledger.
+            auto const irenesOffers = offersOnAccount (env, irene);
+            if (irenesOffers.size() != 0)
+            {
+                expect (irenesOffers.size() == 1);
+                auto const& irenesOffer = *(irenesOffers.front());
+
+                expect (irenesOffer[sfLedgerEntryType] == ltOFFER);
+                expect (irenesOffer[sfTakerGets] == USD (0));
+                expect (irenesOffer[sfTakerPays] == XRP (0));
+            }
+
+            env.require (balance (jimmy, USD(  0)));
+            env.require (balance (jimmy, EUR(100)));
+            env.require (balance (jimmy, XRP(0) + reserve(env, 3)));
+            env.require (offers (jimmy, 0));
+
+            env.require (balance (karen, USD(100)));
+            env.require (balance (karen, EUR(  0)));
+            env.require (balance (karen, XRP(2) + reserve(env, 3)));
+            env.require (offers (karen, 0));
+        }
     }
 
     void run ()
@@ -806,7 +1723,13 @@ public:
         testFillModes ();
         testMalformed ();
         testExpiration ();
+        testPartialCross ();
         testUnfundedCross ();
+        testXRPDirectCross ();
+        testDirectCross();
+        testBridgedCross();
+        testSellOffer();
+        testTransferRateOffer();
     }
 };
 

--- a/src/ripple/app/tx/impl/CreateOffer.h
+++ b/src/ripple/app/tx/impl/CreateOffer.h
@@ -120,6 +120,14 @@ private:
         ApplyView& cancel_view,
         Amounts const& taker_amount);
 
+    // EXPERIMENTAL
+    // See if we can do offer crossing using payment flow code.
+    std::pair<TER, Amounts>
+    flow_cross (
+        ApplyView& view,
+        ApplyView& cancel_view,
+        Amounts const& taker_amount);
+
     static
     std::string
     format_amount (STAmount const& amount);

--- a/src/ripple/app/tx/impl/Offer.h
+++ b/src/ripple/app/tx/impl/Offer.h
@@ -123,6 +123,11 @@ public:
         return to_string (m_entry->getIndex());
     }
 
+    uint256 getIndex () const
+    {
+        return m_entry->getIndex();
+    }
+
     Issue issueIn () const;
     Issue issueOut () const;
 };

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -174,6 +174,16 @@ protected:
 public:
     using TOfferStreamBase<TIn, TOut>::TOfferStreamBase;
 
+    // The following interface allows offer crossing to permanently
+    // remove self crossed offers.  The motivation is somewhat
+    // unintuitive.  See the discussion in the testSelfCrossOffer1()
+    // unit test.
+    void
+    permRmOffer (uint256 const& offerIndex)
+    {
+        permToRemove_.insert (offerIndex);
+    }
+
     boost::container::flat_set<uint256> const& permToRemove () const
     {
         return permToRemove_;

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -1229,7 +1229,7 @@ offerDelete (ApplyView& view,
 
 // Direct send w/o fees:
 // - Redeeming IOUs and/or sending sender's own IOUs.
-// - Create trust line of needed.
+// - Create trust line if needed.
 // --> bCheckIssuer : normally require issuer to be involved.
 TER
 rippleCredit (ApplyView& view,

--- a/src/ripple/test/jtx/impl/offer.cpp
+++ b/src/ripple/test/jtx/impl/offer.cpp
@@ -27,13 +27,25 @@ namespace jtx {
 
 Json::Value
 offer (Account const& account,
-    STAmount const& in, STAmount const& out)
+    STAmount const& in, STAmount const& out,  std::uint32_t flags)
 {
     Json::Value jv;
     jv[jss::Account] = account.human();
     jv[jss::TakerPays] = in.getJson(0);
     jv[jss::TakerGets] = out.getJson(0);
+    if (flags)
+        jv[jss::Flags] = flags;
     jv[jss::TransactionType] = "OfferCreate";
+    return jv;
+}
+
+Json::Value
+offer_cancel (Account const& account, std::uint32_t offerSeq)
+{
+    Json::Value jv;
+    jv[jss::Account] = account.human();
+    jv[jss::OfferSequence] = offerSeq;
+    jv[jss::TransactionType] = "OfferCancel";
     return jv;
 }
 

--- a/src/ripple/test/jtx/offer.h
+++ b/src/ripple/test/jtx/offer.h
@@ -31,7 +31,11 @@ namespace jtx {
 /** Create an offer. */
 Json::Value
 offer (Account const& account,
-    STAmount const& in, STAmount const& out);
+    STAmount const& in, STAmount const& out, std::uint32_t flags = 0);
+
+/** Cancel an offer. */
+Json::Value
+offer_cancel (Account const& account, std::uint32_t offerSeq);
 
 } // jtx
 } // test


### PR DESCRIPTION
I've got the new offer crossing code to the point where all of the unit tests and npm tests pass with both old and new offer crossing.  I'm not done yet, because when I connect to the live network things go bad in a hurry.  But I thought this would be a good point to do a sanity check.

So I've opened a pull request in my own branch.  I invite you to look over the code at your convenience and offer any comments or suggestions you might have.  Scott, I'm interested in your opinion of the damage I've done to your flow code.  Nik, I'm particularly interested in your thoughts on unit tests I may be missing.

To run the new code you have to edit line 912 of CreateOffer.cpp to call `flow_cross()` instead of `cross()` -- same arguments.

No hurry on this.  I'm going to take a short breather and try to come up with a reasonable facility for logging uncaught exceptions.  And I'll be away from work Thursday and Friday this week.  So The soonest I'll be looking at this is next Tuesday.  Even then I won't be blocked; I'll be investigating the badness that happens with my code on the real network.  After I get that stable I'll set up a real-time diff monitor. similar to what Mr. Determan has for payments.
