### PR TITLE
Strongly Typed Wrapper for Escrow objects

### DIFF
--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -367,11 +367,13 @@ EscrowFinish::doApply()
         auto const now = ctx_.view().info().parentCloseTime;
 
         // Too soon: can't execute before the finish time
-        if (escrowObject->finishTime() && !after(now, *escrowObject->finishTime()))
+        if (escrowObject->finishTime() &&
+            !after(now, *escrowObject->finishTime()))
             return tecNO_PERMISSION;
 
         // Too late: can't execute after the cancel time
-        if (escrowObject->cancelTime() && after(now, *escrowObject->cancelTime()))
+        if (escrowObject->cancelTime() &&
+            after(now, *escrowObject->cancelTime()))
             return tecNO_PERMISSION;
     }
     else

--- a/src/ripple/protocol/Escrow.h
+++ b/src/ripple/protocol/Escrow.h
@@ -1,0 +1,102 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2023 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_ESCROW_H_INCLUDED
+#define RIPPLE_PROTOCOL_ESCROW_H_INCLUDED
+
+#include <ripple/protocol/LedgerEntryWrapper.h>
+
+namespace ripple {
+
+template <bool Writable>
+class EscrowImpl final : public LedgerEntryWrapper<Writable>
+{
+private:
+    using Base = LedgerEntryWrapper<Writable>;
+    using SleT = typename Base::SleT;
+    using Base::wrapped_;
+
+    // This constructor is private so only the factory functions can
+    // construct an EscrowImpl.
+    EscrowImpl(std::shared_ptr<SleT>&& w) : Base(std::move(w))
+    {
+    }
+
+    // Friend declarations of factory functions.
+    //
+    // For classes that contain factories we must declare the entire class
+    // as a friend unless the class declaration is visible at this point.
+    friend class ReadView;
+    friend class ApplyView;
+
+public:
+    // Conversion operator from EscrowImpl<true> to EscrowImpl<false>.
+    operator EscrowImpl<true>() const
+    {
+        return EscrowImpl<false>(
+            std::const_pointer_cast<std::shared_ptr<STLedgerEntry const>>(
+                wrapped_));
+    }
+
+    [[nodiscard]] std::optional<uint32_t> finishTime() const {
+        return wrapped_->at(~sfFinishAfter);
+    }
+
+    [[nodiscard]] std::optional<uint32_t> cancelTime() const {
+        return wrapped_->at(~sfCancelAfter);
+    }
+
+    [[nodiscard]] const std::optional<ripple::Slice> checkCondition() const {
+        return wrapped_->at(~sfCondition);
+    }
+
+    [[nodiscard]] AccountID getEscrowRecipient() const {
+        return wrapped_->at(sfDestination);
+    }
+
+    [[nodiscard]] AccountID
+    accountID() const
+    {
+        return wrapped_->at(sfAccount);
+    }
+
+    // This function returns the appropriate page from inside a ledger object.
+    [[nodiscard]] std::uint64_t getOwnerNode() const {
+        return wrapped_->at(sfOwnerNode);
+    }
+
+    // Keshava: Should I explicitly specify the return type or use auto keyword?
+    // returns ripple::OptionalProxy<ripple::STInteger<unsigned long long>>
+    // but OptionalProxy is not accesible from this file
+        [[nodiscard]] auto
+        getRecipientNode() const {
+        return wrapped_->at(~sfDestinationNode);
+    }
+
+    [[nodiscard]] STAmount amount() const {
+        return wrapped_->at(sfAmount);
+    }
+};
+
+using Escrow = EscrowImpl<true>;
+using EscrowRd = EscrowImpl<false>;
+
+}  // namespace ripple
+
+#endif  // RIPPLE_PROTOCOL_ESCROW_H_INCLUDED

--- a/src/ripple/protocol/Escrow.h
+++ b/src/ripple/protocol/Escrow.h
@@ -54,19 +54,27 @@ public:
                 wrapped_));
     }
 
-    [[nodiscard]] std::optional<uint32_t> finishTime() const {
+    [[nodiscard]] std::optional<uint32_t>
+    finishTime() const
+    {
         return wrapped_->at(~sfFinishAfter);
     }
 
-    [[nodiscard]] std::optional<uint32_t> cancelTime() const {
+    [[nodiscard]] std::optional<uint32_t>
+    cancelTime() const
+    {
         return wrapped_->at(~sfCancelAfter);
     }
 
-    [[nodiscard]] const std::optional<ripple::Slice> checkCondition() const {
+    [[nodiscard]] const std::optional<ripple::Slice>
+    checkCondition() const
+    {
         return wrapped_->at(~sfCondition);
     }
 
-    [[nodiscard]] AccountID getEscrowRecipient() const {
+    [[nodiscard]] AccountID
+    getEscrowRecipient() const
+    {
         return wrapped_->at(sfDestination);
     }
 
@@ -77,19 +85,24 @@ public:
     }
 
     // This function returns the appropriate page from inside a ledger object.
-    [[nodiscard]] std::uint64_t getOwnerNode() const {
+    [[nodiscard]] std::uint64_t
+    getOwnerNode() const
+    {
         return wrapped_->at(sfOwnerNode);
     }
 
     // Keshava: Should I explicitly specify the return type or use auto keyword?
     // returns ripple::OptionalProxy<ripple::STInteger<unsigned long long>>
     // but OptionalProxy is not accesible from this file
-        [[nodiscard]] auto
-        getRecipientNode() const {
+    [[nodiscard]] auto
+    getRecipientNode() const
+    {
         return wrapped_->at(~sfDestinationNode);
     }
 
-    [[nodiscard]] STAmount amount() const {
+    [[nodiscard]] STAmount
+    amount() const
+    {
         return wrapped_->at(sfAmount);
     }
 };

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -218,7 +218,7 @@ page(Keylet const& root, std::uint64_t index = 0) noexcept
 /** @} */
 
 /** An escrow entry */
-Keylet
+EscrowKeylet
 escrow(AccountID const& src, std::uint32_t seq) noexcept;
 
 /** A PaymentChannel */

--- a/src/ripple/protocol/Keylet.h
+++ b/src/ripple/protocol/Keylet.h
@@ -120,6 +120,20 @@ static_assert(std::is_move_assignable_v<AccountRootKeylet>);
 static_assert(std::is_nothrow_destructible_v<AccountRootKeylet>);
 #endif
 
+template <bool>
+class EscrowImpl;
+
+struct EscrowKeylet final : public KeyletBase {
+    template <bool Writable>
+    using TWrapped = EscrowImpl<Writable>;
+
+    using KeyletBase::check;
+
+    EscrowKeylet(uint256 const& key) : KeyletBase(ltESCROW, key)
+    {
+    }
+};
+
 }  // namespace ripple
 
 #endif

--- a/src/ripple/protocol/Keylet.h
+++ b/src/ripple/protocol/Keylet.h
@@ -123,7 +123,8 @@ static_assert(std::is_nothrow_destructible_v<AccountRootKeylet>);
 template <bool>
 class EscrowImpl;
 
-struct EscrowKeylet final : public KeyletBase {
+struct EscrowKeylet final : public KeyletBase
+{
     template <bool Writable>
     using TWrapped = EscrowImpl<Writable>;
 

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -314,10 +314,10 @@ page(uint256 const& key, std::uint64_t index) noexcept
     return {ltDIR_NODE, indexHash(LedgerNameSpace::DIR_NODE, key, index)};
 }
 
-Keylet
+EscrowKeylet
 escrow(AccountID const& src, std::uint32_t seq) noexcept
 {
-    return {ltESCROW, indexHash(LedgerNameSpace::ESCROW, src, seq)};
+    return {indexHash(LedgerNameSpace::ESCROW, src, seq)};
 }
 
 Keylet


### PR DESCRIPTION
This commit introduces a new wrapper for Escrow ledger objects through a strongly-typed Escrow keylet. Existing instances of readSLE and peekSLE pertaining to Escrow objects have been updated to use newly proposed read/peek functions.

The wrapper exposes read APIs into the erstwhile STObject::at(...) interface.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
